### PR TITLE
Add Repaint call to BrainEditor after drawing

### DIFF
--- a/Assets/_Project/Scripts/UtilityAI/Editor/BrainEditor.cs
+++ b/Assets/_Project/Scripts/UtilityAI/Editor/BrainEditor.cs
@@ -31,6 +31,8 @@ namespace UtilityAI {
                     // Draw the single consideration for the action
                     DrawConsideration(action.consideration, brain.context, 1);
                 }
+
+                Repaint();
             } else {
                 EditorGUILayout.HelpBox("Enter Play mode to view utility values.", MessageType.Info);
             }


### PR DESCRIPTION
Small update to make the inspector update its view live instead of having to hover over it to see its status.